### PR TITLE
Upgrade HTTP to HTTPS

### DIFF
--- a/difftest/data/invalid_target_config.json
+++ b/difftest/data/invalid_target_config.json
@@ -20,12 +20,12 @@
   },
   {
     "route": "/include/body_proxy",
-    "target": "http://services-internal.glgresearch.com/monitor/",
+    "target": "https://services-internal.glgresearch.com/monitor/",
     "maxAgeInMilliseconds": 0
   },
   {
     "route": "/include/body",
-    "target": "http://services-internal.glgresearch.com/monitor/",
+    "target": "https://services-internal.glgresearch.com/monitor/",
     "maxAgeInMilliseconds": 5000
   },
   {

--- a/difftest/data/unparsable_target_config.json
+++ b/difftest/data/unparsable_target_config.json
@@ -21,12 +21,12 @@
   },
   {
     "route": "/include/body_proxy",
-    "target": "http://services-internal.glgresearch.com/monitor/",
+    "target": "https://services-internal.glgresearch.com/monitor/",
     "maxAgeInMilliseconds": 0
   },
   {
     "route": "/include/body",
-    "target": "http://services-internal.glgresearch.com/monitor/",
+    "target": "https://services-internal.glgresearch.com/monitor/",
     "maxAgeInMilliseconds": 5000
   },
   {

--- a/server.coffee
+++ b/server.coffee
@@ -246,7 +246,7 @@ serveCachedResponse = (context) ->
   context.response.writeHead cachedResponse.statusCode, cachedResponse.headers
   cachedResponse.body.pipe(context.response)
   context.contextEvents.once 'responsefinish', () ->
-    log.info "%s cached response served in %d ms", context.request.url, serveDuration
+    log.debug "%s cached response served in %d ms", context.request.url, serveDuration
   return context
 
 triggerRebuildOfExpiredCachedResponse = (context) ->


### PR DESCRIPTION
This pull request resolves https://github.com/glg/ldap-to-jwt/issues/422 by replacing HTTP references with HTTPS references.

Note that the branch which was used as the base of `deploy3-http-to-https-v1`, `deploy3` was chosen as it is ahead of `master`.