### PR TITLE
Bug: Unlock doesn't always occur

### DIFF
--- a/lib/cache.coffee
+++ b/lib/cache.coffee
@@ -68,7 +68,7 @@ removeCachedResponseFromContext = (context) ->
   return unless context.cachedResponse
   context.contextEvents.removeListener 'clientdisconnect', context.cachedResponse.dispose
   context.contextEvents.removeListener 'responsefinish', context.cachedResponse.dispose
-  context.cachedResponse.dispose()
+  context.cachedResponse?.dispose()
   context.cachedResponse = undefined
 
 getCacheFilePath = (requestInfo) ->

--- a/server.coffee
+++ b/server.coffee
@@ -279,13 +279,13 @@ server = http.createServer (request, response) ->
       # if we've lost our client, this is how we know and as such there is no 
       # sense in keeping the cached response around since we'll never serve it to anyone
       # normally we'd 
-      cache.removeCachedResponseFromContext(context) if context.clientIsDisconnected
       log.debug "disposing of request %d", context.contextId
       if context.cacheLockDescriptor
         log.debug "unlocking cache lock %s during context dispose %d", context.cacheLockDescriptor, context.contextId
         cache.promiseToReleaseCacheLock(context.cacheLockDescriptor)
       else
         log.debug "cache not locked, no unlock needed during context dispose"
+      cache.removeCachedResponseFromContext(context) if context.clientIsDisconnected
 
   requestPipeline = (context) ->
     Promise.resolve(context)


### PR DESCRIPTION
- We cannot find a conclusive reproducable way for a file unlock to
fail. The theory behind this PR is that -if- something goes wrong in
the getContextThatUnlocksCacheOnDispose context, perhaps the unlock
fails. The only thing we see that could go wrong is perhaps the dispose
poos.  SO, our educated guess is unlock first and soak the dispose?